### PR TITLE
refactor1: とりあえずここまで

### DIFF
--- a/src/brainfuck.rs
+++ b/src/brainfuck.rs
@@ -1,0 +1,153 @@
+pub struct BrainFuck {
+    pub code: Vec<u8>,
+    pub c_index: usize,
+    pub buf: Vec<u8>,
+    pub b_index: usize,
+}
+
+impl BrainFuck {
+    pub fn new(code: String) -> Self {
+        Self {
+            code: code.as_bytes().to_vec(),
+            c_index: 0,
+            buf: Vec::new(),
+            b_index: 0,
+        }
+    }
+    pub fn start_process(&mut self) {
+        self.buf.push(0);
+        loop {
+            if self.offset_reached_length() {
+                self.dump();
+                std::process::exit(0);
+            }
+            if self.current_is_eof() {
+                break;
+            }
+            let cur = self.looking_byte() as char;
+            match cur {
+                '+' => {
+                    self.buf[self.b_index] += 1;
+                    self.c_index += 1;
+                }
+                '-' => {
+                    self.buf[self.b_index] -= 1;
+                    self.c_index += 1;
+                }
+                '>' => {
+                    if self.buf[self.b_index] == *self.buf.last().unwrap() {
+                        self.buf.push(0);
+                    }
+                    self.b_index += 1;
+                    self.c_index += 1;
+                }
+                '<' => {
+                    self.b_index -= 1;
+                    self.c_index += 1;
+                }
+                '.' => {
+                    let c: &u8 = self.buf.get(self.b_index).unwrap_or(&0);
+                    print!("{}", *c as char);
+                    self.c_index += 1;
+                }
+                ',' => {
+                    self.get_byte_from_stdin();
+                    self.c_index += 1;
+                }
+                '[' => self.loop_start(),
+                ']' => self.loop_gool(),
+                _ => self.c_index += 1,
+            }
+        }
+    }
+    pub fn dump(&self) {
+        println!("-8<-----8<----8<-----");
+        println!("program end");
+        println!("dump buffer");
+        print!("+-----+");
+        for _ in 0..self.buf.len() {
+            print!("----+");
+        }
+        println!("");
+
+        print!("index |");
+        for i in 0..self.buf.len() {
+            print!("{:>04}|", i);
+        }
+        println!("");
+
+        print!("+-----+");
+        for _ in 0..self.buf.len() {
+            print!("----+");
+        }
+        println!("");
+
+        print!("val   |");
+        for cur in self.buf.clone() {
+            print!("{:>04}|", cur);
+        }
+        println!("");
+
+        print!("+-----+");
+        for _ in 0..self.buf.len() {
+            print!("----+");
+        }
+        println!("");
+    }
+    fn loop_start(&mut self) {
+        if self.buf[self.b_index] == 0 {
+            let mut nest: i64 = 0;
+            let mut _cur: char = 0 as char;
+            loop {
+                self.c_index += 1;
+                _cur = self.code[self.c_index] as char;
+                if _cur == '[' {
+                    nest += 1;
+                } else if _cur == ']' {
+                    nest -= 1;
+                    if nest < 0 {
+                        break;
+                    }
+                }
+            }
+        }
+        self.c_index += 1;
+    }
+
+    fn loop_gool(&mut self) {
+        if self.buf[self.b_index] != 0 {
+            let mut nest: i64 = 0;
+            let mut _cur: char = 0 as char;
+            loop {
+                self.c_index -= 1;
+                _cur = self.code[self.c_index] as char;
+                if _cur == ']' {
+                    nest += 1;
+                } else if _cur == '[' {
+                    nest -= 1;
+                    if nest < 0 {
+                        break;
+                    }
+                }
+            }
+        }
+        self.c_index += 1;
+    }
+    fn current_is_eof(&mut self) -> bool {
+        self.looking_byte() == 0x00
+    }
+    fn looking_byte(&mut self) -> u8 {
+        self.code[self.c_index]
+    }
+    fn offset_reached_length(&mut self) -> bool {
+        self.c_index == self.code.len()
+    }
+    fn get_byte_from_stdin(&mut self) {
+        let mut input = String::new();
+        std::io::stdin()
+            .read_line(&mut input)
+            .ok()
+            .expect("Failed to read line.");
+        self.buf[self.b_index] = input.bytes().nth(0).unwrap_or('\n' as u8);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod brainfuck;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,47 +1,8 @@
 use std::env;
 use std::fs;
 
-struct BrainFuck<'a> {
-    code: &'a std::str::Chars<'a>,
-    c_index: usize,
-    buf: Vec<u8>,
-    b_index: usize
-}
-
-fn dump(buf: Vec<u8>) {
-    println!("-8<-----8<----8<-----");
-    println!("program end");
-    println!("dump buffer");
-    print!("+-----+");
-    for _ in 0..buf.len() {
-        print!("----+");
-    }
-    println!("");
-
-    print!("index |");
-    for i in 0..buf.len() {
-        print!("{:>04}|", i);
-    }
-    println!("");
-
-    print!("+-----+");
-    for _ in 0..buf.len() {
-        print!("----+");
-    }
-    println!("");
-
-    print!("val   |");
-    for cur in buf.clone() {
-        print!("{:>04}|", cur);
-    }
-    println!("");
-
-    print!("+-----+");
-    for _ in 0..buf.len() {
-        print!("----+");
-    }
-    println!("");
-}
+mod brainfuck;
+use brainfuck::BrainFuck;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -57,109 +18,12 @@ fn main() {
 }
 
 fn fuck(code: String) {
-    let _eof: char = 0 as char;
-    let mut fucked = BrainFuck {
-        code: &code.chars(),
-        c_index: 0,
-        buf: Vec::new(),
-        b_index: 0
-    };
-    fucked.buf.push(0);
-    let max = code.chars().count();
-
-    loop {
-        if fucked.c_index == max {
-            dump(fucked.buf);
-            std::process::exit(0);
-        }
-        let cur = fucked.code.clone().nth(fucked.c_index).unwrap();
-        match cur {
-            '+' => {
-                fucked.buf[fucked.b_index] += 1;
-                fucked.c_index += 1;
-            },
-            '-' => {
-                fucked.buf[fucked.b_index] -= 1;
-                fucked.c_index += 1;
-            },
-            '>' => {
-                if fucked.buf[fucked.b_index] == *fucked.buf.last().unwrap() {
-                    fucked.buf.push(0);
-                }
-                fucked.b_index += 1;
-                fucked.c_index += 1;
-            },
-            '<' => {
-                fucked.b_index -= 1;
-                fucked.c_index += 1;
-            },
-            '.' => {
-                let c: &u8 = fucked.buf.get(fucked.b_index).unwrap_or(&0);
-                print!("{}", *c as char);
-                fucked.c_index += 1;
-            },
-            ',' => {
-                getc(&mut fucked.buf[fucked.b_index]);
-                fucked.c_index += 1;
-            },
-            '[' => bf_loop_start(&mut fucked),
-            ']' => bf_loop_gool(&mut fucked),
-            tmp if tmp == _eof => break,
-            _ => fucked.c_index += 1,
-        }
-    }
+    let mut fucked = BrainFuck::new(code);
+    fucked.start_process();
 }
 
-fn bf_loop_start(fucked: &mut BrainFuck) {
-    if fucked.buf[fucked.b_index] == 0 {
-        let mut nest: i64 = 0;
-        let mut _cur: char = 0 as char;
-        loop {
-            fucked.c_index += 1;
-            _cur = fucked.code.clone().nth(fucked.c_index).unwrap();
-            if _cur == '[' {
-                nest += 1;
-            } else if _cur == ']' {
-                nest -= 1;
-                if nest < 0 {
-                    break;
-                }
-            }
-        }
-    }
-    fucked.c_index += 1;
-}
-
-fn bf_loop_gool(fucked: &mut BrainFuck) {
-    if fucked.buf[fucked.b_index] != 0 {
-        let mut nest: i64 = 0;
-        let mut _cur: char = 0 as char;
-        loop {
-            fucked.c_index -= 1;
-            _cur = fucked.code.clone().nth(fucked.c_index).unwrap();
-            if _cur == ']' {
-                nest += 1;
-            } else if _cur =='[' {
-                nest -= 1;
-                if nest < 0 {
-                    break;
-                }
-            }
-        }
-    }
-    fucked.c_index += 1;
-}
-
-fn usage() {
+fn usage() -> ! {
     let name: Vec<String> = env::args().collect();
     eprintln!("Usage: {} [source file]", name[0]);
     std::process::exit(1);
-}
-
-fn getc(buf: &mut u8) {
-    let mut input = String::new();
-    std::io::stdin().read_line(&mut input)
-        .ok().expect("Failed to read line.");
-    *buf = input.bytes().nth(0)
-        .unwrap_or('\n' as u8);
 }


### PR DESCRIPTION
- 構造体を別ファイルに分ける
- 構造体のbufを操作するコードはできるだけメソッドに
- EOFチェックとかそこら辺を全部メソッドにして意味づけ
- あと多分今回のBrainfuckは記号しか扱わないので `Chars`よりも バイト列でいい
  - こうすると最初にファイルを読み込む時 `Vec<u8>` で受け取ると更に省メモリ
  - `String.as_bytes().to_vec()` でコピーが走るので
  - 参照: [記事](https://qiita.com/fujitayy/items/12a80560a356607da637#%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E3%81%AE%E5%86%85%E5%AE%B9%E5%85%A8%E4%BD%93%E3%82%92%E3%83%90%E3%82%A4%E3%83%88%E5%88%97%E3%81%A8%E3%81%97%E3%81%A6%E4%B8%80%E6%B0%97%E3%81%AB%E8%AA%AD%E3%81%BF%E8%BE%BC%E3%81%BF)
- cloneとか減らした,できるだけ